### PR TITLE
Expand questionnaire

### DIFF
--- a/constants/questions.py
+++ b/constants/questions.py
@@ -2,9 +2,22 @@ QUESTION1 = 'Em qual cliente foi realizado o serviço?'
 QUESTION2 = 'Que horário foi realizado o serviço?'
 QUESTION3 = 'Escreva aqui o seu diário de obra dos serviços que foram realizados:'
 QUESTION4 = 'Qual o horário de chegada no cliente?'
-QUESTION5 = 'XX'
-QUESTION6 = 'XX'
-QUESTION7 = 'XX'
+QUESTION5 = 'Qual o horário de saída do cliente?'
+QUESTION6 = 'Quanto tempo de deslocamento até a empresa?'
+QUESTION7 = 'Há alguma observação adicional sobre o serviço?'
+QUESTION8 = 'Qual a equipe presente no serviço?'
+QUESTION9 = 'Quais materiais foram utilizados?'
+QUESTION10 = 'Houve alguma ocorrência fora do previsto?'
+QUESTION11 = 'O cliente aprovou os serviços realizados?'
+QUESTION12 = 'Existe alguma pendência a ser resolvida?'
+QUESTION13 = 'O equipamento utilizado apresentou problemas?'
+QUESTION14 = 'Foram seguidas as normas de segurança?'
+QUESTION15 = 'Qual a previsão de conclusão dos próximos passos?'
+QUESTION16 = 'O local de trabalho foi deixado limpo e organizado?'
+QUESTION17 = 'Houve necessidade de suporte adicional?'
+QUESTION18 = 'Como foi a comunicação com o cliente?'
+QUESTION19 = 'Descreva os próximos passos planejados.'
+QUESTION20 = 'Alguma sugestão para melhorar o atendimento?'
 
 QUESTIONS = {
     1: QUESTION1,
@@ -13,8 +26,21 @@ QUESTIONS = {
     4: QUESTION4,
     5: QUESTION5,
     6: QUESTION6,
-    7: QUESTION7
+    7: QUESTION7,
+    8: QUESTION8,
+    9: QUESTION9,
+    10: QUESTION10,
+    11: QUESTION11,
+    12: QUESTION12,
+    13: QUESTION13,
+    14: QUESTION14,
+    15: QUESTION15,
+    16: QUESTION16,
+    17: QUESTION17,
+    18: QUESTION18,
+    19: QUESTION19,
+    20: QUESTION20,
 }
 
 # Quantidade máxima de perguntas
-NUMERO_MAXIMO_QUESTOES = 3
+NUMERO_MAXIMO_QUESTOES = 20

--- a/scripts/datasheet_services.py
+++ b/scripts/datasheet_services.py
@@ -168,7 +168,7 @@ class DataSheetServices:
           - A linha com id_questionario == row[0]
         receba 'answer'.
         Exemplo de cabeçalho:
-        [id_questionario, "1", "2", "3", "4", "5", "6", "7"]
+        [id_questionario, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"]
         """
         # Lê tudo da planilha "questions"
         ws = (
@@ -178,9 +178,31 @@ class DataSheetServices:
         )
         data = ws.get_all_values()
 
-        # Se estiver vazia, cria um cabeçalho padrão (até 7 perguntas, por ex.)
+        # Se estiver vazia, cria um cabeçalho padrão (até 20 perguntas, por ex.)
         if not data:
-            data = [["id_questionario", "1", "2", "3", "4", "5", "6", "7"]]
+            data = [[
+                "id_questionario",
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9",
+                "10",
+                "11",
+                "12",
+                "13",
+                "14",
+                "15",
+                "16",
+                "17",
+                "18",
+                "19",
+                "20",
+            ]]
 
         header = data[0]
 


### PR DESCRIPTION
## Summary
- expand the questionnaire to 20 items
- create larger header template for 20 columns

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685346791c408330902f5e29c1049c35